### PR TITLE
make gpasswd provider work with forcelocal => true

### DIFF
--- a/lib/puppet/provider/group/gpasswd.rb
+++ b/lib/puppet/provider/group/gpasswd.rb
@@ -12,6 +12,7 @@ Puppet::Type.type(:group).provide :gpasswd, :parent => Puppet::Type::Group::Prov
             :delmember => 'gpasswd'
 
   has_feature :manages_members unless %w{HP-UX Solaris}.include? Facter.value(:operatingsystem)
+  has_feature :libuser if Puppet.features.libuser?
 
   def addcmd
     # This pulls in the main group add command should the group need
@@ -93,7 +94,7 @@ Puppet::Type.type(:group).provide :gpasswd, :parent => Puppet::Type::Group::Prov
   def mod_group(cmds)
     cmds.each do |run_cmd|
       begin
-        execute(run_cmd)
+        execute(run_cmd,:custom_environment => @custom_environment)
       rescue Puppet::ExecutionFailure => e
         if $?.exitstatus == 3 then
           Puppet.warning("Modifying #{@resource[:name]} => #{e}")

--- a/lib/puppet/provider/group/gpasswd.rb
+++ b/lib/puppet/provider/group/gpasswd.rb
@@ -45,6 +45,7 @@ Puppet::Type.type(:group).provide :gpasswd, :parent => Puppet::Type::Group::Prov
   end
 
   def members
+    getinfo(true) if @objectinfo.nil?
     retval = @objectinfo.mem
 
     if @resource[:members] and


### PR DESCRIPTION
The provider was showing this error:

```
Debug: /Group[testgroup]: Provider gpasswd does not support features libuser; not managing attribute forcelocal
```

Now it works and this module does not create groups with uid 10000+ which are ldap users!
