### PR TITLE
(SIMP-4085) Fix system_groups

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+* Tue Nov 28 2017 Nick Markowski <nicholas.markowski@onyxpoint.com> - 1.0.4-0
+- 1.0.3 was tagged, bumping to 1.0.4
+- Fix addresses https://github.com/onyxpoint/puppet-gpasswd/issues/7
+- Before this fix, users could not specify groups in the system
+  GID range, SYS_GID_[MAX,MIN] in /etc/login.defs. Added system_groups
+  feature to gpasswd.
+- Added beaker tests to ensure groups can be created within the system range.
+
 * Sun May 21 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.0.2-0
   - Fixed README typos
   - Cleaned up code

--- a/lib/puppet/provider/group/gpasswd.rb
+++ b/lib/puppet/provider/group/gpasswd.rb
@@ -13,6 +13,7 @@ Puppet::Type.type(:group).provide :gpasswd, :parent => Puppet::Type::Group::Prov
 
   has_feature :manages_members unless %w{HP-UX Solaris}.include? Facter.value(:operatingsystem)
   has_feature :libuser if Puppet.features.libuser?
+  has_feature :system_groups unless %w{HP-UX Solaris}.include? Facter.value(:operatingsystem)
 
   def addcmd
     # This pulls in the main group add command should the group need

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "onyxpoint-gpasswd",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": "Trevor Vaughan <tvaughan@onyxpoint.com>",
   "summary": "Adds support for :manages_members to the Linux group native type",
   "license": "Apache-2.0",

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -23,7 +23,7 @@ describe 'gpasswd' do
       $users = ['#{users.join("','")}']
       $users.each |$user| { user { $user: ensure => 'present' } }
 
-      group { 'test': members => $users, auth_membership => #{auth_membership} }
+      group { '#{group}': members => $users, system => #{system}, auth_membership => #{auth_membership} }
     EOM
   }
 
@@ -31,6 +31,8 @@ describe 'gpasswd' do
     context 'with a sorted list of users' do
       let(:users) { hoopy_froods.sort }
       let(:auth_membership) { true }
+      let(:system) { false }
+      let(:group) { 'test' }
 
       # Using puppet_apply as a helper
       it 'should work with no errors' do
@@ -42,7 +44,7 @@ describe 'gpasswd' do
       end
 
       it 'should have populated the group' do
-        group_members = on(host, 'getent group test').output.strip.split(':').last.split(',')
+        group_members = on(host, "getent group #{group}").output.strip.split(':').last.split(',')
 
         expect(group_members - users).to be_empty
       end
@@ -51,6 +53,8 @@ describe 'gpasswd' do
     context 'with an unsorted list of users' do
       let(:users) { hoopy_froods - [hoopy_froods.last] }
       let(:auth_membership) { true }
+      let(:system) { false }
+      let(:group) { 'test' }
 
       # Using puppet_apply as a helper
       it 'should work with no errors' do
@@ -62,7 +66,7 @@ describe 'gpasswd' do
       end
 
       it 'should have populated the group' do
-        group_members = on(host, 'getent group test').output.strip.split(':').last.split(',')
+        group_members = on(host, "getent group #{group}").output.strip.split(':').last.split(',')
 
         expect(group_members - users).to be_empty
       end
@@ -71,6 +75,8 @@ describe 'gpasswd' do
     context 'when replacing existing users' do
       let(:users) { meddling_kids }
       let(:auth_membership) { true }
+      let(:system) { false }
+      let(:group) { 'test' }
 
       # Using puppet_apply as a helper
       it 'should work with no errors' do
@@ -82,7 +88,7 @@ describe 'gpasswd' do
       end
 
       it 'should have populated the group' do
-        group_members = on(host, 'getent group test').output.strip.split(':').last.split(',')
+        group_members = on(host, "getent group #{group}").output.strip.split(':').last.split(',')
 
         expect(group_members - users).to be_empty
       end
@@ -91,6 +97,8 @@ describe 'gpasswd' do
     context 'when adding all users' do
       let(:users) { hoopy_froods }
       let(:auth_membership) { false }
+      let(:system) { false }
+      let(:group) { 'test' }
 
       # Using puppet_apply as a helper
       it 'should work with no errors' do
@@ -102,9 +110,41 @@ describe 'gpasswd' do
       end
 
       it 'should have populated the group' do
-        group_members = on(host, 'getent group test').output.strip.split(':').last.split(',')
+        group_members = on(host, "getent group #{group}").output.strip.split(':').last.split(',')
 
         expect(group_members - (users + meddling_kids)).to be_empty
+      end
+    end
+
+    context 'when adding system groups' do
+      let(:users) { ['user1', 'user2'] }
+      let(:auth_membership) { true }
+      let(:system) { true }
+      let(:group) { 'test_system' }
+
+      # Set the SYS_GID_[MAX/MIN] to be 499 so we can ensure we have a GID
+      # within range
+      it 'should set SYS_GID_[MAX,MIN] to 499' do
+        on(host, "/usr/bin/grep -q 'SYS_GID_MIN' /etc/login.defs && /usr/bin/sed -i 's/SYS_GID_MIN.*/SYS_GID_MIN 499/g' /etc/login.defs || /usr/bin/echo 'SYS_GID_MIN 499' >> /etc/login.defs")
+        on(host, "/usr/bin/grep -q 'SYS_GID_MAX' /etc/login.defs && /usr/bin/sed -i 's/SYS_GID_MAX.*/SYS_GID_MAX 499/g' /etc/login.defs || /usr/bin/echo 'SYS_GID_MAX 499' >> /etc/login.defs")
+      end
+
+      # Using puppet_apply as a helper
+      it 'should work with no errors' do
+        apply_manifest_on(host, manifest, :catch_failures => true)
+      end
+      it 'should be idempotent' do
+        apply_manifest_on(host, manifest, {:catch_changes => true})
+      end
+
+      it 'should have populated the group' do
+        group_members = on(host, "getent group #{group}").output.strip.split(':').last.split(',')
+        expect(group_members - ['user1','user2']).to be_empty
+      end
+
+      it 'should have a GID of 499' do
+        group_gid = on(host, "getent group #{group}").output.strip.split(':')[2]
+        expect(group_gid).to eq '499'
       end
     end
   end


### PR DESCRIPTION
- 1.0.3 was tagged, bumping to 1.0.4
- Fix addresses https://github.com/onyxpoint/puppet-gpasswd/issues/7
- Before this fix, users could not specify groups in the system
  GID range, SYS_GID_[MAX,MIN] in /etc/login.defs. Added system_groups
  feature to gpasswd.
- Added beaker tests to ensure groups can be created within the system range.

SIMP-4085 #close