### PR TITLE
Support emptying groups when no members in list and `auth_membership` is true

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Thu Oct 19 2023 David Gardner <github.com@icmfp.com> - 1.1.4-0
+- Add support for emptying group when no members are specified (#20)
+
 * Sun Oct 03 2021 Iain Hallam <iain@nineworlds.net> - 1.1.3-0
 - Add support for Debian
 

--- a/lib/puppet/provider/group/gpasswd.rb
+++ b/lib/puppet/provider/group/gpasswd.rb
@@ -129,19 +129,17 @@ Puppet::Type.type(:group).provide :gpasswd, :parent => Puppet::Type::Group::Prov
       to_be_added = to_set.dup
     end
 
-    unless to_be_added.empty?
-      if @resource[:auth_membership]
-        cmd << [ command(:modmember),'-M',to_be_added.join(','), @resource[:name] ].shelljoin
-      else
-        to_be_added = to_be_added | @current_members
+    if @resource[:auth_membership]
+      cmd << [ command(:modmember),'-M',to_be_added.join(','), @resource[:name] ].shelljoin
+    else
+      to_be_added = to_be_added | @current_members
 
-        !to_be_added.empty? && cmd += to_be_added.map { |x|
-          [ command(:addmember),'-a',x,@resource[:name] ].shelljoin
-        }
-      end
-
-      mod_group(cmd)
+      !to_be_added.empty? && cmd += to_be_added.map { |x|
+        [ command(:addmember),'-a',x,@resource[:name] ].shelljoin
+      }
     end
+
+    mod_group(cmd)
   end
 
   private

--- a/lib/puppet/provider/group/gpasswd.rb
+++ b/lib/puppet/provider/group/gpasswd.rb
@@ -108,10 +108,9 @@ Puppet::Type.type(:group).provide :gpasswd, :parent => Puppet::Type::Group::Prov
           Puppet::Etc.send('getpwnam', user)
         end
 
-        Puppet.debug("Ignoring unknown user: '#{user}'")
-
         false
       rescue
+        Puppet.debug("Ignoring unknown user: '#{user}'")
 
         true
       end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "onyxpoint-gpasswd",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "author": "Trevor Vaughan <tvaughan@onyxpoint.com>",
   "summary": "Adds support for :manages_members to the Linux group native type",
   "license": "Apache-2.0",


### PR DESCRIPTION
This just allows passing through of the empty `to_be_added` list to the `gpasswd -M` arguments list, which causes the group to indeed be emptied successfully.

(Also moved the "Ignoring unknown user" debug print to the rescue block in `members_insync?`, as this is where the control jumps to on getpwuid or getpwnam throwing an exception when the user isn't found.  No logic change, just that the message was printed when users were found rather than not :+1: )